### PR TITLE
Compute final weight relative to baseline

### DIFF
--- a/TrackWeight/WeighingViewModel.swift
+++ b/TrackWeight/WeighingViewModel.swift
@@ -151,7 +151,8 @@ final class WeighingViewModel: ObservableObject {
     }
     
     private func completeWeighing() {
-        state = .result(weight: currentPressure)
+        finalWeight = currentPressure - baselinePressure
+        state = .result(weight: finalWeight)
         stopListening()
     }
     
@@ -170,7 +171,8 @@ final class WeighingViewModel: ObservableObject {
             }
             
             if state == .weighing {
-                if hasDetectedItem && finalWeight > 0 {
+                if hasDetectedItem {
+                    finalWeight = currentPressure - baselinePressure
                     state = .result(weight: finalWeight)
                     stopListening()
                 }


### PR DESCRIPTION
## Summary
- calculate `finalWeight` as the difference between `currentPressure` and `baselinePressure`
- present `finalWeight` when measurement finishes or the finger is lifted

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688270ee16548326bfa538b6da629016