### PR TITLE
Remove unused gradient code

### DIFF
--- a/TrackWeight/ScaleView.swift
+++ b/TrackWeight/ScaleView.swift
@@ -15,16 +15,7 @@ struct ScaleView: View {
         if #available(macOS 14.0, *) {
             GeometryReader { geometry in
                 ZStack {
-                    // Animated gradient background
-//                    LinearGradient(
-//                        colors: [
-//                            Color(red: 0.95, green: 0.97, blue: 1.0),
-//                            Color(red: 0.85, green: 0.92, blue: 0.98)
-//                        ],
-//                        startPoint: .topLeading,
-//                        endPoint: .bottomTrailing
-//                    )
-//                    .ignoresSafeArea()
+                    // Plain background (gradient disabled)
                     
                     VStack(spacing: geometry.size.height * 0.06) {
                         // Title with subtitle directly underneath


### PR DESCRIPTION
## Summary
- delete leftover gradient code in `ScaleView.swift`
- note that the gradient is disabled in the comment

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688270ee6c1c8326a3f82ba597f7a0c7