### PR TITLE
Add weight unit selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [TrackWeight](https://x.com/KrishRShah/status/1947186835811193330) is a macOS application that transforms your MacBook's trackpad into an accurate weighing scale by leveraging the Force Touch pressure sensors built into modern MacBook trackpads.
 
+The app supports displaying weights in either grams or ounces. Choose your preferred unit from the scale interface.
+
 https://github.com/user-attachments/assets/7eaf9e0b-3dec-4829-b868-f54a8fd53a84
 
 To use it yourself:

--- a/TrackWeight/ScaleView.swift
+++ b/TrackWeight/ScaleView.swift
@@ -10,6 +10,7 @@ struct ScaleView: View {
     @State private var scaleCompression: CGFloat = 0
     @State private var displayShake = false
     @State private var particleOffset: CGFloat = 0
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         if #available(macOS 14.0, *) {
@@ -55,6 +56,7 @@ struct ScaleView: View {
                                 displayShake: $displayShake,
                                 scaleFactor: min(geometry.size.width / 700, geometry.size.height / 500)
                             )
+                            .environmentObject(unitSettings)
                             Spacer()
                         }
                         
@@ -67,7 +69,15 @@ struct ScaleView: View {
                                     .font(.system(size: min(max(geometry.size.width * 0.018, 12), 16), weight: .medium))
                                     .foregroundStyle(.gray)
                             }
-                            
+
+                            Picker("Unit", selection: $unitSettings.unit) {
+                                ForEach(WeightUnit.allCases) { unit in
+                                    Text(unit.symbol).tag(unit)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .frame(width: 120)
+
                             Button(action: {
                                 viewModel.zeroScale()
                             }) {
@@ -135,6 +145,7 @@ struct CartoonScaleView: View {
     @Binding var compression: CGFloat
     @Binding var displayShake: Bool
     let scaleFactor: CGFloat
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         VStack(spacing: 0) {
@@ -187,13 +198,14 @@ struct CartoonScaleView: View {
                 
                 // Weight display
                 VStack(spacing: 2) {
-                    Text(String(format: "%.1f", weight))
+                    let displayValue = unitSettings.unit.convertFromGrams(weight)
+                    Text(String(format: "%.1f", displayValue))
                         .font(.system(size: 32 * scaleFactor, weight: .bold, design: .monospaced))
                         .foregroundStyle(.white)
                         .shadow(color: .teal, radius: hasTouch ? 2 : 0)
                         .animation(.easeInOut(duration: 0.2), value: weight)
                     
-                    Text("grams")
+                    Text(unitSettings.unit.symbol)
                         .font(.system(size: 12 * scaleFactor, weight: .medium))
                         .foregroundStyle(.white.opacity(0.8))
                 }

--- a/TrackWeight/TrackWeightApp.swift
+++ b/TrackWeight/TrackWeightApp.swift
@@ -10,10 +10,12 @@ import SwiftUI
 @main
 struct TrackWeightApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var unitSettings = UnitSettings()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(unitSettings)
         }
     }
 }

--- a/TrackWeight/TrackWeightView.swift
+++ b/TrackWeight/TrackWeightView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct TrackWeightView: View {
     @StateObject private var viewModel = WeighingViewModel()
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         VStack(spacing: 30) {
@@ -15,6 +16,7 @@ struct TrackWeightView: View {
                 WelcomeView {
                     viewModel.startWeighing()
                 }
+                .environmentObject(unitSettings)
                 
             case .waitingForFinger:
                 FingerTimerView(
@@ -36,11 +38,13 @@ struct TrackWeightView: View {
                     isStabilizing: viewModel.isStabilizing,
                     stabilityProgress: viewModel.stabilityProgress
                 )
+                .environmentObject(unitSettings)
                 
             case .result(let weight):
                 ResultView(weight: weight) {
                     viewModel.restart()
                 }
+                .environmentObject(unitSettings)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -51,6 +55,7 @@ struct TrackWeightView: View {
 
 struct WelcomeView: View {
     let onStart: () -> Void
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         VStack(spacing: 25) {
@@ -62,7 +67,7 @@ struct WelcomeView: View {
                 .font(.system(size: 36, weight: .bold, design: .rounded))
                 .foregroundStyle(.primary)
             
-            Text("Turn your trackpad into a precision scale. Place objects and get their weight in grams.")
+            Text("Turn your trackpad into a precision scale. Place objects and get their weight in \(unitSettings.unit.symbol).")
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -201,6 +206,7 @@ struct WeighingView: View {
     let currentPressure: Float
     let isStabilizing: Bool
     let stabilityProgress: Float
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         VStack(spacing: 30) {
@@ -209,12 +215,13 @@ struct WeighingView: View {
                 .foregroundStyle(.primary)
             
             VStack(spacing: 10) {
-                Text(String(format: "%.1f", currentPressure))
+                let displayValue = unitSettings.unit.convertFromGrams(currentPressure)
+                Text(String(format: "%.1f", displayValue))
                     .font(.system(size: 64, weight: .bold, design: .monospaced))
                     .foregroundStyle(.blue)
                     .animation(.easeInOut(duration: 0.2), value: currentPressure)
                 
-                Text("grams")
+                Text(unitSettings.unit.symbol)
                     .font(.system(size: 20, weight: .medium))
                     .foregroundStyle(.secondary)
             }
@@ -269,6 +276,7 @@ struct WeighingView: View {
 struct ResultView: View {
     let weight: Float
     let onRestart: () -> Void
+    @EnvironmentObject private var unitSettings: UnitSettings
     
     var body: some View {
         VStack(spacing: 30) {
@@ -287,11 +295,12 @@ struct ResultView: View {
                 .foregroundStyle(.secondary)
             
             VStack(spacing: 5) {
-                Text(String(format: "%.1f", weight))
+                let displayValue = unitSettings.unit.convertFromGrams(weight)
+                Text(String(format: "%.1f", displayValue))
                     .font(.system(size: 56, weight: .bold, design: .monospaced))
                     .foregroundStyle(.primary)
                 
-                Text("grams")
+                Text(unitSettings.unit.symbol)
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(.secondary)
             }

--- a/TrackWeight/UnitSettings.swift
+++ b/TrackWeight/UnitSettings.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@MainActor
+final class UnitSettings: ObservableObject {
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.grams.rawValue {
+        didSet {
+            objectWillChange.send()
+        }
+    }
+
+    var unit: WeightUnit {
+        get { WeightUnit(rawValue: weightUnitRaw) ?? .grams }
+        set { weightUnitRaw = newValue.rawValue }
+    }
+}

--- a/TrackWeight/WeightUnit.swift
+++ b/TrackWeight/WeightUnit.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum WeightUnit: String, CaseIterable, Identifiable {
+    case grams
+    case ounces
+
+    var id: String { rawValue }
+
+    var symbol: String {
+        switch self {
+        case .grams: return "g"
+        case .ounces: return "oz"
+        }
+    }
+
+    /// Factor to convert from grams to this unit
+    var factor: Float {
+        switch self {
+        case .grams: return 1.0
+        case .ounces: return 0.03527396
+        }
+    }
+
+    func convertFromGrams(_ grams: Float) -> Float {
+        return grams * factor
+    }
+}


### PR DESCRIPTION
## Summary
- allow changing units between grams and ounces
- persist preferred unit with `UnitSettings`
- show current unit in ScaleView and guided TrackWeightView
- document new unit toggle in README

## Testing
- `swift test -v` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688271649b2c8326a3a3b17657c074f4